### PR TITLE
Make `cacheable` type consistent

### DIFF
--- a/json/methods.json
+++ b/json/methods.json
@@ -76,7 +76,7 @@
         "description": "",
         "safe": false,
         "idempotent": true,
-        "cacheable": "",
+        "cacheable": false,
         "spec_title": "RFC3744#8.1",
         "spec_href": "http://tools.ietf.org/html/rfc3744#section-8.1"
     },
@@ -85,7 +85,7 @@
         "description": "",
         "safe": false,
         "idempotent": true,
-        "cacheable": "",
+        "cacheable": false,
         "spec_title": "RFC3253#12.6",
         "spec_href": "http://tools.ietf.org/html/rfc3253#section-12.6"
     },
@@ -94,7 +94,7 @@
         "description": "",
         "safe": false,
         "idempotent": true,
-        "cacheable": "",
+        "cacheable": false,
         "spec_title": "RFC5842#4",
         "spec_href": "http://tools.ietf.org/html/rfc5842#section-4"
     },
@@ -103,7 +103,7 @@
         "description": "",
         "safe": false,
         "idempotent": true,
-        "cacheable": "",
+        "cacheable": false,
         "spec_title": "RFC3253#4.4",
         "spec_href": "http://tools.ietf.org/html/rfc3253#section-4.4"
     },
@@ -112,7 +112,7 @@
         "description": "",
         "safe": false,
         "idempotent": true,
-        "cacheable": "",
+        "cacheable": false,
         "spec_title": "RFC3253#4.3",
         "spec_href": "http://tools.ietf.org/html/rfc3253#section-4.3"
     },
@@ -121,7 +121,7 @@
         "description": "",
         "safe": false,
         "idempotent": true,
-        "cacheable": "",
+        "cacheable": false,
         "spec_title": "RFC4918#9.8",
         "spec_href": "http://tools.ietf.org/html/rfc4918#section-9.8"
     },
@@ -130,7 +130,7 @@
         "description": "",
         "safe": false,
         "idempotent": true,
-        "cacheable": "",
+        "cacheable": false,
         "spec_title": "RFC3253#8.2",
         "spec_href": "http://tools.ietf.org/html/rfc3253#section-8.2"
     },
@@ -139,7 +139,7 @@
         "description": "",
         "safe": false,
         "idempotent": true,
-        "cacheable": "",
+        "cacheable": false,
         "spec_title": "RFC2068#19.6.1.2",
         "spec_href": "http://tools.ietf.org/html/rfc2068#section-19.6.1.2"
     },
@@ -148,7 +148,7 @@
         "description": "",
         "safe": false,
         "idempotent": false,
-        "cacheable": "",
+        "cacheable": false,
         "spec_title": "RFC4918#9.10",
         "spec_href": "http://tools.ietf.org/html/rfc4918#section-9.10"
     },
@@ -157,7 +157,7 @@
         "description": "",
         "safe": false,
         "idempotent": true,
-        "cacheable": "",
+        "cacheable": false,
         "spec_title": "RFC3253#11.2",
         "spec_href": "http://tools.ietf.org/html/rfc3253#section-11.2"
     },
@@ -166,7 +166,7 @@
         "description": "",
         "safe": false,
         "idempotent": true,
-        "cacheable": "",
+        "cacheable": false,
         "spec_title": "RFC3253#13.5",
         "spec_href": "http://tools.ietf.org/html/rfc3253#section-13.5"
     },
@@ -175,7 +175,7 @@
         "description": "",
         "safe": false,
         "idempotent": true,
-        "cacheable": "",
+        "cacheable": false,
         "spec_title": "RFC4791#5.3.1",
         "spec_href": "http://tools.ietf.org/html/rfc4791#section-5.3.1"
     },
@@ -184,7 +184,7 @@
         "description": "",
         "safe": false,
         "idempotent": true,
-        "cacheable": "",
+        "cacheable": false,
         "spec_title": "RFC4918#9.3",
         "spec_href": "http://tools.ietf.org/html/rfc4918#section-9.3"
     },
@@ -193,7 +193,7 @@
         "description": "",
         "safe": false,
         "idempotent": true,
-        "cacheable": "",
+        "cacheable": false,
         "spec_title": "RFC4437#6",
         "spec_href": "http://tools.ietf.org/html/rfc4437#section-6"
     },
@@ -202,7 +202,7 @@
         "description": "",
         "safe": false,
         "idempotent": true,
-        "cacheable": "",
+        "cacheable": false,
         "spec_title": "RFC3253#6.3",
         "spec_href": "http://tools.ietf.org/html/rfc3253#section-6.3"
     },
@@ -211,7 +211,7 @@
         "description": "",
         "safe": false,
         "idempotent": true,
-        "cacheable": "",
+        "cacheable": false,
         "spec_title": "RFC4918#9.9",
         "spec_href": "http://tools.ietf.org/html/rfc4918#section-9.9"
     },
@@ -220,7 +220,7 @@
         "description": "",
         "safe": false,
         "idempotent": true,
-        "cacheable": "",
+        "cacheable": false,
         "spec_title": "RFC3648#7",
         "spec_href": "http://tools.ietf.org/html/rfc3648#section-7"
     },
@@ -238,7 +238,7 @@
         "description": "",
         "safe": true,
         "idempotent": true,
-        "cacheable": "",
+        "cacheable": false,
         "spec_title": "RFC4918#9.1",
         "spec_href": "http://tools.ietf.org/html/rfc4918#section-9.1"
     },
@@ -247,7 +247,7 @@
         "description": "",
         "safe": false,
         "idempotent": true,
-        "cacheable": "",
+        "cacheable": false,
         "spec_title": "RFC4918#9.2",
         "spec_href": "http://tools.ietf.org/html/rfc4918#section-9.2"
     },
@@ -256,7 +256,7 @@
         "description": "",
         "safe": false,
         "idempotent": true,
-        "cacheable": "",
+        "cacheable": false,
         "spec_title": "RFC5842#6",
         "spec_href": "http://tools.ietf.org/html/rfc5842#section-6"
     },
@@ -265,7 +265,7 @@
         "description": "",
         "safe": true,
         "idempotent": true,
-        "cacheable": "",
+        "cacheable": false,
         "spec_title": "RFC3253#3.6",
         "spec_href": "http://tools.ietf.org/html/rfc3253#section-3.6"
     },
@@ -274,7 +274,7 @@
         "description": "",
         "safe": true,
         "idempotent": true,
-        "cacheable": "",
+        "cacheable": false,
         "spec_title": "RFC5323#2",
         "spec_href": "http://tools.ietf.org/html/rfc5323#section-2"
     },
@@ -283,7 +283,7 @@
         "description": "",
         "safe": false,
         "idempotent": true,
-        "cacheable": "",
+        "cacheable": false,
         "spec_title": "RFC5842#5",
         "spec_href": "http://tools.ietf.org/html/rfc5842#section-5"
     },
@@ -292,7 +292,7 @@
         "description": "",
         "safe": false,
         "idempotent": true,
-        "cacheable": "",
+        "cacheable": false,
         "spec_title": "RFC3253#4.5",
         "spec_href": "http://tools.ietf.org/html/rfc3253#section-4.5"
     },
@@ -301,7 +301,7 @@
         "description": "",
         "safe": false,
         "idempotent": true,
-        "cacheable": "",
+        "cacheable": false,
         "spec_title": "RFC2068#19.6.1.3",
         "spec_href": "http://tools.ietf.org/html/rfc2068#section-19.6.1.3"
     },
@@ -310,7 +310,7 @@
         "description": "",
         "safe": false,
         "idempotent": true,
-        "cacheable": "",
+        "cacheable": false,
         "spec_title": "RFC4918#9.11",
         "spec_href": "http://tools.ietf.org/html/rfc4918#section-9.11"
     },
@@ -319,7 +319,7 @@
         "description": "",
         "safe": false,
         "idempotent": true,
-        "cacheable": "",
+        "cacheable": false,
         "spec_title": "RFC3253#7.1",
         "spec_href": "http://tools.ietf.org/html/rfc3253#section-7.1"
     },
@@ -328,7 +328,7 @@
         "description": "",
         "safe": false,
         "idempotent": true,
-        "cacheable": "",
+        "cacheable": false,
         "spec_title": "RFC4437#7",
         "spec_href": "http://tools.ietf.org/html/rfc4437#section-7"
     },
@@ -337,7 +337,7 @@
         "description": "",
         "safe": false,
         "idempotent": true,
-        "cacheable": "",
+        "cacheable": false,
         "spec_title": "RFC3253#3.5",
         "spec_href": "http://tools.ietf.org/html/rfc3253#section-3.5"
     }


### PR DESCRIPTION
For some methods instead of `false` the `cacheable` property was set to an empty string.
